### PR TITLE
A patch to the ino file, where the GPIOs for I2C_SDA and I2C_SCL are defined, so that the scratch can be directly used. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To build an example sketch
  - (Re)start Arduino.
  - Open File > Example > Examples from Custom Libraries > ScioSense_ENS16x > 01_Basic (or any other of the provided examples you wish to run)
  - Make sure Tools > Board lists the correct board.
+ - Make sure the GPIOs for I2C on the ESP32 (I2C_SDA and I2C_SCL) in use are correct.
  - Select Sketch > Verify/Compile.
 
 ## Acknowledgements

--- a/examples/01_Basic/ENS160/ENS160.ino
+++ b/examples/01_Basic/ENS160/ENS160.ino
@@ -11,6 +11,8 @@ I2cInterface i2c;
 
 #define USE_INTERRUPT
 #define INTN 2
+#define I2C_SDA 21
+#define I2C_SCL 22
 
 ENS160 ens160;
 
@@ -19,7 +21,7 @@ void setup()
     Serial.begin(9600);
     ens160.enableDebugging(Serial);
 
-    Wire.begin();
+    Wire.begin(I2C_SDA,I2C_SCL,0);
     i2c.begin(Wire, I2C_ADDRESS);
 
     Serial.println("begin..");

--- a/examples/01_Basic/ENS160/ENS160.ino
+++ b/examples/01_Basic/ENS160/ENS160.ino
@@ -1,3 +1,4 @@
+// wanring: before usage please make sure the GPIOs for I2C on the ESP32 (I2C_SDA and I2C_SCL) in use are correct.
 #include <Arduino.h>
 #include <Wire.h>
 #include <ScioSense_ENS16x.h>


### PR DESCRIPTION
define the GPIOs designated for I2C communication for ESP32, the define should be adapted according to the specific controller in use.

I believe this patch is necessary, because ESP32 is the only example mentioned in the readme file, thus most of users can run the example with ESP32 directly without diving into the codes to make changes.