### PR TITLE
Update interrupt pin mode to INPUT_PULLUP

### DIFF
--- a/src/ens16x.inl.h
+++ b/src/ens16x.inl.h
@@ -214,7 +214,7 @@ uint8_t* ENS16x::getDataRaw()
 
 void ENS16x::setInterruptPin(int p)
 {
-    pinMode(p, INPUT);
+    pinMode(p, INPUT_PULLUP);
     interruptPin = p;
 }
 


### PR DESCRIPTION
by default the pin is open drain, pullup so we can see the change without needing external resistor